### PR TITLE
Added "id" as third param to example function in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ Helper to simply implement a worker [RSMQ ( Redis Simple Message Queue )](https:
   var RSMQWorker = require( "rsmq-worker" );
   var worker = new RSMQWorker( "myqueue" );
 
-  worker.on( "message", function( msg, next ){
+  worker.on( "message", function( msg, next, id ){
   	// process your message
+  	console.log("Message id : " + id);
+  	console.log(msg);
   	next()
   });
 


### PR DESCRIPTION
Key point for this commit is that "id" of the message can be leveraged as the third parameter for worker.on function. And that, "id" is not available as msg.id.

worker.on( "message", function( msg, next, id ){ 
// Example
use "id" to delete the message, once processed.
}