### PR TITLE
Add Node 7 to appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,8 @@ environment:
     - nodejs_version: "0.12"
     - nodejs_version: "4"
     - nodejs_version: "5"
+    - nodejs_version: "6"
+    - nodejs_version: "7"
 
 pull_requests:
   do_not_increment_build_number: true


### PR DESCRIPTION
This PR adds versions 6.x and 7.x of Node for AppVeyour tests.
On my branch the tests are passing:
https://ci.appveyor.com/project/rsp/rsmq-worker/build/1