### PR TITLE
Replaced rawgit.com urls with combinatronics.com urls.

### DIFF
--- a/_src/lib/rsmq-worker.coffee
+++ b/_src/lib/rsmq-worker.coffee
@@ -1,6 +1,6 @@
 # # RSMQWorker
 
-# ### extends [NPM:MPBasic](https://cdn.rawgit.com/mpneuried/mpbaisc/master/_docs/index.coffee.html)
+# ### extends [NPM:MPBasic](https://cdn.combinatronics.com/mpneuried/mpbaisc/master/_docs/index.coffee.html)
 
 #
 # ### Exports: *Class*


### PR DESCRIPTION
Combinatronics.com is a drop in replacement for rawgit.com which is EOL.